### PR TITLE
Handle expired photo URLs and improve fallbacks

### DIFF
--- a/src/components/employes/FichePersonnel/tabs/OngletInfosPersonnelles.tsx
+++ b/src/components/employes/FichePersonnel/tabs/OngletInfosPersonnelles.tsx
@@ -73,7 +73,7 @@ export const OngletInfosPersonnelles: React.FC<OngletInfosPersonnellesProps> = (
       nif: '',
       email_perso: '',
       telephone: '',
-      lien_photo: '',
+      lien_photo: '', // chemin relatif dans le bucket (ex: 'clientId/nom.jpg')
       id_tiers: '',
       actif: true,
       code_court: '',
@@ -266,7 +266,14 @@ export const OngletInfosPersonnelles: React.FC<OngletInfosPersonnellesProps> = (
           // Charger l'aperçu de la photo si disponible
           if (data.lien_photo) {
             console.log('Chargement de l\'aperçu de la photo:', data.lien_photo);
-            loadPhotoPreview(data.lien_photo, setPhotoPreview);
+            const preview = await loadPhotoPreview(data.lien_photo, setPhotoPreview);
+            if (!preview) {
+              addToast({
+                label: 'Impossible de charger la photo',
+                icon: 'AlertTriangle',
+                color: '#f59e0b'
+              });
+            }
           }
         } catch (error) {
           console.error('Erreur lors du chargement du personnel:', error);
@@ -380,7 +387,14 @@ export const OngletInfosPersonnelles: React.FC<OngletInfosPersonnellesProps> = (
         
         // Mettre à jour l'aperçu de la photo si nécessaire
         if (result.lien_photo) {
-          loadPhotoPreview(result.lien_photo, setPhotoPreview);
+          const preview = await loadPhotoPreview(result.lien_photo, setPhotoPreview);
+          if (!preview) {
+            addToast({
+              label: 'Impossible de charger la photo',
+              icon: 'AlertTriangle',
+              color: '#f59e0b'
+            });
+          }
         } else {
           setPhotoPreview(null);
         }

--- a/src/components/employes/FichePersonnel/tabs/hooks/usePhotoManagement.ts
+++ b/src/components/employes/FichePersonnel/tabs/hooks/usePhotoManagement.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { supabase } from '../../../../../lib/supabase';
 import { useProfil } from '../../../../../context/ProfilContext';
 import { ToastData } from '../../../../../components/ui/toast';
@@ -13,27 +13,63 @@ export const usePhotoManagement = (props?: UsePhotoManagementProps) => {
   const { profil } = useProfil();
   const [photoPreview, setPhotoPreview] = useState<string | null>(null);
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
-  
+  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Fonction pour charger l'aperçu de la photo
-  const loadPhotoPreview = async (photoPath: string, setPreview: (url: string | null) => void) => {
+  const loadPhotoPreview = async (
+    photoPath: string,
+    setPreview: (url: string | null) => void
+  ): Promise<string | null> => {
     try {
       console.log('Génération de l\'URL signée pour la photo:', photoPath);
       const { data, error } = await supabase
         .storage
         .from('personnel-photos')
-        .createSignedUrl(photoPath, 60);
-      
-      if (error) {
+        .createSignedUrl(photoPath, 3600);
+
+      if (error || !data?.signedUrl) {
         console.error('Erreur lors de la création de l\'URL signée:', error);
-        throw error;
+        if (props?.addToast) {
+          props.addToast({
+            label: "Impossible de générer le lien de la photo",
+            icon: 'AlertTriangle',
+            color: '#ef4444'
+          });
+        }
+        setPreview(null);
+        return null;
       }
 
       console.log('URL signée créée avec succès, longueur:', data.signedUrl.length);
       setPreview(data.signedUrl);
+
+      if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
+      refreshTimeoutRef.current = setTimeout(() => {
+        loadPhotoPreview(photoPath, setPreview);
+      }, 55 * 60 * 1000);
+
+      return data.signedUrl;
     } catch (error) {
       console.error('Erreur lors du chargement de la photo:', error);
+      if (props?.addToast) {
+        props.addToast({
+          label: 'Erreur lors du chargement de la photo',
+          icon: 'AlertTriangle',
+          color: '#ef4444'
+        });
+      }
+      setPreview(null);
+      return null;
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Gérer l'upload de la photo
   const handlePhotoUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -74,7 +110,7 @@ export const usePhotoManagement = (props?: UsePhotoManagementProps) => {
       }
       
       // Charger l'aperçu
-      loadPhotoPreview(filePath, setPhotoPreview);
+      await loadPhotoPreview(filePath, setPhotoPreview);
       
       if (props?.addToast) {
         props.addToast({
@@ -116,6 +152,10 @@ export const usePhotoManagement = (props?: UsePhotoManagementProps) => {
         console.log('Valeur du champ lien_photo après suppression:', props?.getValues ? props.getValues('lien_photo') : null);
       }
       setPhotoPreview(null);
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
+        refreshTimeoutRef.current = null;
+      }
       
       if (props?.addToast) {
         props.addToast({


### PR DESCRIPTION
## Summary
- Extend Supabase photo preview signed URL lifetime to one hour and auto-refresh before expiry
- Show error toasts when signed URL generation fails and clear preview state on removal
- Document expected `lien_photo` path and notify users when photo preview cannot be loaded

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9aabb3198832a8c959c3fb87c70e0